### PR TITLE
Only allow delete by group owner

### DIFF
--- a/src/components/pages/GroupsPage/ViewSingleGroup/ViewSingleGroup.tsx
+++ b/src/components/pages/GroupsPage/ViewSingleGroup/ViewSingleGroup.tsx
@@ -81,7 +81,6 @@ export default function ViewSingleGroup() {
   };
 
   if (isLoading) {
-    // return <GroupSkelly />;
     return "";
   }
 
@@ -194,10 +193,10 @@ export default function ViewSingleGroup() {
 
             {/* ----ADD MEMBER BUTTON---- */}
             <div className={styles.buttonRow}>
-              {/* @ts-ignore "groupId is null checked" */}
               <AddMember group={group} />
 
               {/* ----DELETE BUTTON---- */}
+              {group.ownerId === user._id && (
               <Dialog>
                 <DialogTrigger asChild>
                   <Button className="deleteButton">Delete This Group</Button>
@@ -223,6 +222,7 @@ export default function ViewSingleGroup() {
                   </div>
                 </DialogContent>
               </Dialog>
+              )}
             </div>
           </div>
 


### PR DESCRIPTION
This pull request includes several changes to the `ViewSingleGroup` component in the `GroupsPage`. The updates primarily involve cleaning up the code and adding conditional rendering for the delete button.

Code cleanup and improvements:

* Removed commented-out return statement for `GroupSkelly` when `isLoading` is true.
* Removed `@ts-ignore` comment for the `AddMember` component, assuming `groupId` is properly null-checked elsewhere.

Conditional rendering:

* Added conditional rendering for the delete button, making it visible only if the current user is the owner of the group. [[1]](diffhunk://#diff-8cb80671a6ea1776344fb326089a838facc63220abb151763ca44abdf8d46953L197-R199) [[2]](diffhunk://#diff-8cb80671a6ea1776344fb326089a838facc63220abb151763ca44abdf8d46953R225)