### PR TITLE
Chat scroll

### DIFF
--- a/src/components/pages/EventsPage/ViewEvents/SingleEvent/Chat/Chat.tsx
+++ b/src/components/pages/EventsPage/ViewEvents/SingleEvent/Chat/Chat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   getDatabase,
   ref,
@@ -32,9 +32,19 @@ export default function Chat({ eventId }: props) {
   const [message, setMessage] = useState("");
   const { user } = useAuth();
   const [isEditting, setIsEditting] = useState<Message | null>(null);
+  const bottomWindowRef = useRef<HTMLDivElement>(null);
 
   //@ts-ignore loadingMessage will be used in the future
   const [loadingMessages, setLoadingMessages] = useState(true);
+
+  const scrollToBottom = () => {
+    if (bottomWindowRef.current) {
+      const container = bottomWindowRef.current.parentElement;
+      if (container) {
+        container.scrollTop = container.scrollHeight;
+      }
+    }
+  };
 
   useEffect(() => {
     const db = getDatabase();
@@ -107,6 +117,10 @@ export default function Chat({ eventId }: props) {
     };
   }, [eventId]);
 
+  useEffect(()=>{
+    scrollToBottom()
+  },[messages])
+
   useEffect(() => {
     //  editting / updating chat message
     if (isEditting?.id) {
@@ -167,6 +181,7 @@ export default function Chat({ eventId }: props) {
             <MessageCard message={message} sendEditData={setIsEditting} />
           </div>
         ))}
+        <div ref={bottomWindowRef}/>
       </div>
 
       {/* ----Text Area---- */}

--- a/src/components/pages/EventsPage/ViewEvents/SingleEvent/Chat/Chat.tsx
+++ b/src/components/pages/EventsPage/ViewEvents/SingleEvent/Chat/Chat.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   getDatabase,
   ref,

--- a/src/components/pages/EventsPage/ViewEvents/SingleEvent/Chat/Styles.module.css
+++ b/src/components/pages/EventsPage/ViewEvents/SingleEvent/Chat/Styles.module.css
@@ -4,22 +4,23 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  /* justify-content: space-between; */
 }
 
 .chatHeader {
   border-bottom: 1px solid lightgray;
   padding-bottom: 0.5em;
+  flex-shrink: 0; /* Prevent header from shrinking */
 }
 
 .messageContainer {
-  height: 100%;
+  flex: 1;  /* Take up remaining space */
   padding-top: 1em;
-  padding-bottom: 8em;
+  padding-bottom: 9em; /* Increased to account for form height */
   display: flex;
   flex-direction: column;
   gap: 0.5em;
   overflow-y: auto;
+  position: relative; /* Add this */
 }
 
 .textDiv {


### PR DESCRIPTION
This pull request introduces several changes to the chat functionality on the `EventsPage` to improve user experience, particularly focusing on automatic scrolling to the bottom of the chat and layout adjustments.

### Chat functionality improvements:

* [`src/components/pages/EventsPage/ViewEvents/SingleEvent/Chat/Chat.tsx`](diffhunk://#diff-64d040eb575a0eb0c653cbfebd1e243d3d2a29becdb65847c59a6494380b92acL1-R1): Added a `useRef` hook to create a reference to the bottom of the chat window and a `scrollToBottom` function to automatically scroll to the bottom when new messages are loaded. This ensures that users always see the latest messages. [[1]](diffhunk://#diff-64d040eb575a0eb0c653cbfebd1e243d3d2a29becdb65847c59a6494380b92acL1-R1) [[2]](diffhunk://#diff-64d040eb575a0eb0c653cbfebd1e243d3d2a29becdb65847c59a6494380b92acR35-R48) [[3]](diffhunk://#diff-64d040eb575a0eb0c653cbfebd1e243d3d2a29becdb65847c59a6494380b92acR120-R123) [[4]](diffhunk://#diff-64d040eb575a0eb0c653cbfebd1e243d3d2a29becdb65847c59a6494380b92acR184)

### Layout adjustments:

* [`src/components/pages/EventsPage/ViewEvents/SingleEvent/Chat/Styles.module.css`](diffhunk://#diff-b379daf3afa12e4d826d76ee14156dfe74f9e5bb2b78e504b06adf9bd82e6fe8L7-R23): Modified the `.chatHeader` and `.messageContainer` styles to prevent the header from shrinking and to ensure the message container takes up the remaining space. This provides a better visual layout and accommodates the chat form height.